### PR TITLE
Bump dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdf_glyph_renderer"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Ian Wagner <ian@stadiamaps.com>"]
 license = "BSD-3-Clause"
 repository = "https://github.com/stadiamaps/sdf_glyph_renderer"
@@ -17,5 +17,5 @@ freetype = ["freetype-rs"]
 derive-error = "~0.0"
 
 [dependencies.freetype-rs]
-version = "~0.26"
+version = "^0.27"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2018"
 freetype = ["freetype-rs"]
 
 [dependencies]
-derive-error = "~0.0"
+derive-error = "0.0.5"
 
 [dependencies.freetype-rs]
-version = "^0.27"
+version = "0.27.0"
 optional = true


### PR DESCRIPTION
- Upgrades to `freetype 0.27`.
- Uses implied dependency specification.