### PR TITLE
Doc fix (markdown bails at <f64>)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ pub fn render_sdf(bitmap: &BitmapGlyph, radius: usize) -> Vec<f64> {
         .collect()
 }
 
-/// Compresses a Vec<f64> into a Vec<u8> for efficiency.
+/// Compresses a `Vec<f64>` into a `Vec<u8>` for efficiency.
 ///
 /// The highest `cutoff` percent of values in the range (0-255) will be used to encode
 /// negative values (points inside the glyph). This can be tuned based on the intended


### PR DESCRIPTION
... because it looks like an HTML tag!

Yeah it's boring like that. https://docs.rs/sdf_glyph_renderer/latest/sdf_glyph_renderer/fn.clamp_to_u8.html for where it breaks.